### PR TITLE
demo: use element.async instead of RAF & Platform.flush

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -73,9 +73,8 @@
           return;
         }
         progress.value = progress.min;
-        Platform.flush();
       }
-      requestAnimationFrame(nextProgress);
+      progress.async(nextProgress);
     }
     
     function startProgress() {


### PR DESCRIPTION
The [docs for element.async](http://www.polymer-project.org/docs/polymer/polymer.html#asyncmethod) imply that this can be used for out of scope changes and the source makes use of Platform.flush (similarly to $scope.$apply in angular) but I'm not sure what the best practice would be.

As with issue #1 things work great when object.observe is available but the polyfill on its own doesn't trigger enough for a smooth animation and it's pretty easy to forget to Platform.flush
