### PR TITLE
Fixed typo in javascript documentation

### DIFF
--- a/paper-progress.html
+++ b/paper-progress.html
@@ -21,7 +21,7 @@ progress, such as the buffer level during a streaming playback progress bar.
 
 Example:
 
-    <paper-progress value="10" secondaryProgesss="30"></paper-progress>
+    <paper-progress value="10" secondaryProgress="30"></paper-progress>
 
 Styling progress bar:
 


### PR DESCRIPTION
```
Example:

    <paper-progress value="10" secondaryProgesss="30"></paper-progress>
```
Corrected spelling:  "secondaryProgesss" changed to "secondaryProgress"

```
Example:

    <paper-progress value="10" secondaryProgress="30"></paper-progress>
```